### PR TITLE
Develop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM centos:centos7
+RUN yum install -y epel-release \
+    && yum install -y unar
 
 WORKDIR /scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM centos:centos7
-RUN yum install -y epel-release \
+RUN localedef -f UTF-8 -i ja_JP ja_JP.UTF-8 \
+    && yum install -y epel-release \
     && yum install -y unar
+
+ENV LANG="ja_JP.UTF-8" \
+    LANGUAGE="ja_JP:ja" \
+    LC_ALL="ja_JP.UTF-8"
 
 WORKDIR /scripts

--- a/monitor_directory.sh
+++ b/monitor_directory.sh
@@ -18,6 +18,7 @@ function help() {
 
   Options:
     -h: ヘルプを表示
+    -d: 実行処理の最後の引数に処理対象ディレクトリを設定
 __EOF__
   exit 1
 }
@@ -45,8 +46,6 @@ function check_exec() {
 function monitor() {
   # シェルの絶対パスを取得
   local shPath=`readlink -f ${exec}` 
-  # ディレクトリ移動
-  cd ${path}
 
   while :;do
     sh ${shPath} ${params}
@@ -55,12 +54,16 @@ function monitor() {
 }
 
 # option
-while getopts :h OPT
+while getopts :hd OPT
 do
   case ${OPT} in
   h)
     shift
     help
+    ;;
+  d)
+    shift
+    FLAG_D=1
     ;;
   esac
 done
@@ -75,6 +78,10 @@ interval=$2
 exec=$3
 shift 3
 params=$@
+# -d option
+if [ -n "${FLAG_D}" ]; then
+  params="${params} ${path}"
+fi
 
 # parameters check
 check_path

--- a/unzip.sh
+++ b/unzip.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+function help() {
+  cat << __EOF__
+
+  $0
+  ============
+
+  Description:
+    指定ディレクトリ内の*.zipファイルを解凍する
+
+  Usage:
+    $0 [-h] [-p password] [-o output_path] [-d] target_directory
+    \$1 処理対象ディレクトリ
+
+  Options:
+    -h: ヘルプを表示
+    -p: zipファイルのパスワードを指定
+    -o: 解凍先を指定
+    -d: 元zipファイルを消す
+__EOF__
+  exit 1
+}
+
+function check_directory() {
+  targetDirectory=$1
+  if [ ! -e ${targetDirectory} ]; then
+    echo "The Directory ${targetDirectory} is not exists!!"
+    exit 1
+  fi
+}
+
+function unzip() {
+  if [ -n "${password}" ]; then
+    opts="${opts} -p ${password}"
+  fi
+
+  if [ -n "${outputDir}" ]; then
+    opts="${opts} -o ${outputDir}"
+  fi
+
+  find ${targetDir} -maxdepth 1 -type f -name '*.zip' | while read file
+  do
+    unar ${opts} -r "${file}"
+    if [ -n "${DELETE_FILE}" ]; then
+      rm -f "${file}"
+    fi
+  done
+}
+
+# option
+while getopts :hp:o:d OPT
+do
+  case ${OPT} in
+  h)
+    help
+    ;;
+  p)
+    password=${OPTARG}
+    ;;
+  o)
+    outputDir=${OPTARG}
+    ;;
+  d)
+    DELETE_FILE=1
+    ;;
+  esac
+done
+shift $(($OPTIND - 1))
+
+# parameters
+if [ $# -ne 1 ]; then
+  echo 'parameter is invalid'
+  help
+fi
+targetDir=$1
+
+# parameters check
+check_directory ${targetDir}
+if [ -n "${outputDir}" ]; then
+  check_directory ${outputDir}
+fi
+
+# exec
+unzip


### PR DESCRIPTION
unzip.shの追加に伴う対応

Dockerfile
  unarを使える環境を構築
  rhel(ver. 8)だとepel7のリポジトリが設定されておらず、
  設定後にunarをinstallしようとすると、ライブラリ不足が起こる
  aws環境では再現しなかったため、修正する必要もないのでcentOsに切替

monitor_directory.sh
  内部でシェルを呼び出す際の挙動を修正
  オプション追加し、内部でシェルを呼び出す際に監視対象のディレクトリをパラメータとした渡せるように修正

  また、内部でシェルを呼び出す前に、シェルが置いてあるディレクトリにcdしていたが、
  実際使うとなると、下記の様な問題があった。

【問題例】
  ① monitor-directory.shからは call.shを呼び出す
  ② call.shはパラメータで渡された、別のディレクトリrefを参照する

【ディレクトリ構成】
  monitor-directory.sh
  ├ sh_dir - call.sh
  └ ref

  従来は事前にcd sh_dir をしていたので、call.shの内部でrefを参照するには
  今はmonitor-directory.shのディレクトリにいるのに、call.shと refの相対パスを指定する必要があった
  ※ ./monitor-directory.sh call.sh ../ref
  修正したので、下記の様に呼び出せる
  ※ ./monitor-directory.sh call.sh ./ref

unzip.sh
  指定されたディレクトリに格納された、zipファイルを解凍するスクリプト